### PR TITLE
Revert to jQuery v1.11.1

### DIFF
--- a/isaviewer-demo.html
+++ b/isaviewer-demo.html
@@ -51,8 +51,8 @@
 </div>
 
 <link href="isaviewer_assets/css/ISATabViewer.css" rel="stylesheet" type="text/css"/>
-<!-- <script type="text/javascript" src="isaviewer_assets/js/jquery-1.11.1.min.js"></script> -->
-<script type="text/javascript" src="isaviewer_assets/js/jquery-2.2.4.js"></script>
+<script type="text/javascript" src="isaviewer_assets/js/jquery-1.11.1.min.js"></script>
+<!-- <script type="text/javascript" src="isaviewer_assets/js/jquery-2.2.4.js"></script> -->
 <script type="text/javascript" src="isaviewer_assets/js/handlebars-v1.3.0.js"></script>
 <script type="text/javascript" src="isaviewer_assets/js/ISATabViewer.js"></script>
 <!-- <script type="text/javascript" src="isaviewer_assets/js/jszip.min.js"></script> -->


### PR DESCRIPTION
 Because jQuery v2.2.4 is not included in the repo, it 404s, then nothing works in the `isaviewer-demo.html`. This fixes things.